### PR TITLE
CodeFix. Передавалось неверное имя класса

### DIFF
--- a/src/services/transactions.py
+++ b/src/services/transactions.py
@@ -45,11 +45,11 @@ class TransactionAddingFailedError(TransactionsServiceError):
     pass
 
 
-class TransactionNotExists(TransactionServiceError):
+class TransactionNotExists(TransactionsServiceError):
     pass
 
 
-class OtherUserTransaction(TransactionServiceError):
+class OtherUserTransaction(TransactionsServiceError):
     pass
 
 


### PR DESCRIPTION
### Изменения
- Добавлена буква "S" в Transaction^ServiceError